### PR TITLE
Make account popover match toolbar background

### DIFF
--- a/Source/RFAccountPopoverBox.m
+++ b/Source/RFAccountPopoverBox.m
@@ -26,7 +26,7 @@
 - (void) updateBackground
 {
 	if ([self.effectiveAppearance rf_isDarkMode]) {
-		self.fillColor = NSColor.textBackgroundColor;
+		self.fillColor = NSColor.clearColor;
 	}
 	else {
 		self.fillColor = self.originalLightColor;


### PR DESCRIPTION
Before:

<img width="680" alt="Screen Shot 2021-11-07 at 2 10 30 AM" src="https://user-images.githubusercontent.com/16448027/140637674-5f1fde7c-a6dd-4e0e-a370-92d38bd15be7.png">

After:

<img width="682" alt="Screen Shot 2021-11-07 at 2 11 31 AM" src="https://user-images.githubusercontent.com/16448027/140637683-eeebed2f-0731-4301-906d-cdf5b2a9baaf.png">

I was only able to test with one account, so I'm not sure how this will interact with the mouse over color change.
