### PR TITLE
Improve Day One Export

### DIFF
--- a/Resources/Base.lproj/Preferences.xib
+++ b/Resources/Base.lproj/Preferences.xib
@@ -18,11 +18,11 @@
                 <outlet property="messageTopConstraint" destination="xBT-xn-WX9" id="drj-is-oYf"/>
                 <outlet property="postFormatField" destination="TEJ-Cy-YA6" id="8F0-g7-Wpe"/>
                 <outlet property="postFormatPopup" destination="uK0-xJ-ygW" id="Ygg-pX-V8O"/>
-                <outlet property="progressSpinner" destination="GsW-0h-utd" id="Gty-Zd-J7e"/>
                 <outlet property="publishHostedBlog" destination="8Eh-Mk-bT3" id="msC-FJ-7pL"/>
                 <outlet property="publishWordPressBlog" destination="T0C-fL-nk1" id="uJN-8G-DXX"/>
                 <outlet property="textSizePopup" destination="iVr-XZ-NWu" id="Sk4-Pd-Oiw"/>
                 <outlet property="websiteField" destination="1e3-uC-J1t" id="MVu-b2-eYH"/>
+                <outlet property="websiteProgressSpinner" destination="GsW-0h-utd" id="Gty-Zd-J7e"/>
                 <outlet property="websiteReturnButton" destination="yk6-d0-KBL" id="Z43-hF-jJz"/>
                 <outlet property="window" destination="QvC-M9-y7g" id="hRW-hv-vMb"/>
                 <outlet property="wordPressSeparatorLine" destination="GX3-D2-htv" id="p1R-v1-Bdj"/>
@@ -354,6 +354,24 @@
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
+                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="76n-nb-d2Y" userLabel="Day One Return Button">
+                        <rect key="frame" x="371" y="24" width="22" height="22"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="22" id="DTG-ic-Imw"/>
+                            <constraint firstAttribute="width" constant="22" id="v1L-yV-Wjs"/>
+                        </constraints>
+                        <buttonCell key="cell" type="bevel" title="↩︎" bezelStyle="rounded" alignment="center" imageScaling="proportionallyDown" inset="2" id="OUj-p5-jIE">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                    </button>
+                    <progressIndicator wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" displayedWhenStopped="NO" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="wkZ-P7-NAg" userLabel="Day One Progress Indicator">
+                        <rect key="frame" x="374" y="27" width="16" height="16"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="16" id="BfB-1U-grd"/>
+                            <constraint firstAttribute="height" constant="16" id="uI5-QN-ohS"/>
+                        </constraints>
+                    </progressIndicator>
                 </subviews>
                 <constraints>
                     <constraint firstItem="GX3-D2-htv" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="20" id="0cP-Yy-b90"/>
@@ -372,6 +390,7 @@
                     <constraint firstItem="zil-dW-qZT" firstAttribute="top" secondItem="blp-LE-vz2" secondAttribute="bottom" id="CNW-ti-bgO"/>
                     <constraint firstItem="VRq-Zm-nw2" firstAttribute="top" secondItem="T0C-fL-nk1" secondAttribute="bottom" constant="24" id="DWl-mp-mwJ"/>
                     <constraint firstAttribute="trailing" secondItem="zil-dW-qZT" secondAttribute="trailing" constant="20" id="EaY-Ck-kva"/>
+                    <constraint firstItem="wkZ-P7-NAg" firstAttribute="centerY" secondItem="Pub-fF-3Iv" secondAttribute="centerY" id="FOl-LK-PkB"/>
                     <constraint firstAttribute="trailing" secondItem="GX3-D2-htv" secondAttribute="trailing" constant="20" id="GCf-da-Abr"/>
                     <constraint firstItem="yk6-d0-KBL" firstAttribute="leading" secondItem="1e3-uC-J1t" secondAttribute="trailing" constant="5" id="HSh-kT-1cn"/>
                     <constraint firstItem="Jez-ql-5hu" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="20" id="Hh4-2N-kdd"/>
@@ -381,9 +400,11 @@
                     <constraint firstItem="uK0-xJ-ygW" firstAttribute="top" secondItem="1e3-uC-J1t" secondAttribute="bottom" constant="49" id="Lag-vY-Nzf"/>
                     <constraint firstItem="blp-LE-vz2" firstAttribute="leading" secondItem="HEb-qM-PKK" secondAttribute="trailing" constant="8" id="MiD-b5-sLP"/>
                     <constraint firstItem="zil-dW-qZT" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="20" id="NMp-LJ-WFw"/>
+                    <constraint firstItem="GsW-0h-utd" firstAttribute="width" secondItem="wkZ-P7-NAg" secondAttribute="width" id="ON2-NW-3QM"/>
                     <constraint firstItem="iVr-XZ-NWu" firstAttribute="top" secondItem="e0X-yV-XWC" secondAttribute="bottom" constant="17" id="P9q-Qh-2kS"/>
                     <constraint firstItem="e0X-yV-XWC" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="-1" id="PnO-91-67S"/>
                     <constraint firstItem="GX3-D2-htv" firstAttribute="top" secondItem="VRq-Zm-nw2" secondAttribute="bottom" constant="22" id="Q2Z-oj-qtK"/>
+                    <constraint firstItem="yk6-d0-KBL" firstAttribute="width" secondItem="76n-nb-d2Y" secondAttribute="width" id="QEp-CT-afH"/>
                     <constraint firstItem="1e3-uC-J1t" firstAttribute="width" secondItem="Pub-fF-3Iv" secondAttribute="width" id="QJ4-mz-v1h"/>
                     <constraint firstItem="GsW-0h-utd" firstAttribute="top" secondItem="T0C-fL-nk1" secondAttribute="bottom" constant="25" id="Ray-VT-9TY"/>
                     <constraint firstItem="TEJ-Cy-YA6" firstAttribute="top" secondItem="VRq-Zm-nw2" secondAttribute="bottom" constant="45" id="TPU-ao-7Na"/>
@@ -400,17 +421,20 @@
                     <constraint firstAttribute="trailing" secondItem="FOb-i6-SLf" secondAttribute="trailing" constant="20" id="cDl-HJ-age"/>
                     <constraint firstItem="Pub-fF-3Iv" firstAttribute="leading" secondItem="tcY-90-dE6" secondAttribute="trailing" constant="9" id="cNB-4Y-zpS"/>
                     <constraint firstItem="iVr-XZ-NWu" firstAttribute="leading" secondItem="wxE-lU-Q6W" secondAttribute="trailing" constant="8" id="ctQ-ZB-NQM"/>
+                    <constraint firstItem="76n-nb-d2Y" firstAttribute="centerY" secondItem="Pub-fF-3Iv" secondAttribute="centerY" id="daw-Hh-xF7"/>
                     <constraint firstItem="yk6-d0-KBL" firstAttribute="top" secondItem="T0C-fL-nk1" secondAttribute="bottom" constant="23" id="eZ9-66-wrY"/>
                     <constraint firstAttribute="trailing" secondItem="dAB-WX-QVA" secondAttribute="trailing" constant="41" id="iab-wJ-4Hp"/>
                     <constraint firstAttribute="trailing" secondItem="yk6-d0-KBL" secondAttribute="trailing" constant="15" id="idx-6e-ggp"/>
                     <constraint firstItem="HEb-qM-PKK" firstAttribute="top" secondItem="wxE-lU-Q6W" secondAttribute="bottom" constant="31" id="kWw-NK-uIN"/>
                     <constraint firstItem="n60-Ec-rID" firstAttribute="top" secondItem="TEJ-Cy-YA6" secondAttribute="bottom" constant="14" id="kbl-Ri-LVu"/>
                     <constraint firstItem="TEJ-Cy-YA6" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="16" id="mzZ-RR-i7f"/>
+                    <constraint firstItem="yk6-d0-KBL" firstAttribute="centerX" secondItem="76n-nb-d2Y" secondAttribute="centerX" id="o25-O9-4fu"/>
                     <constraint firstItem="1e3-uC-J1t" firstAttribute="top" secondItem="T0C-fL-nk1" secondAttribute="bottom" constant="22" id="pdg-GY-Z4a"/>
                     <constraint firstItem="Pub-fF-3Iv" firstAttribute="firstBaseline" secondItem="tcY-90-dE6" secondAttribute="firstBaseline" id="q06-Py-ZmY"/>
                     <constraint firstItem="wxE-lU-Q6W" firstAttribute="top" secondItem="e0X-yV-XWC" secondAttribute="bottom" constant="18" id="tWe-du-IoH"/>
                     <constraint firstItem="tcY-90-dE6" firstAttribute="top" secondItem="FOb-i6-SLf" secondAttribute="bottom" constant="22" id="tjl-fl-Q18"/>
                     <constraint firstItem="Jez-ql-5hu" firstAttribute="top" secondItem="zil-dW-qZT" secondAttribute="bottom" constant="15" id="vDa-At-JUF"/>
+                    <constraint firstItem="GsW-0h-utd" firstAttribute="centerX" secondItem="wkZ-P7-NAg" secondAttribute="centerX" id="vLC-QV-2t4"/>
                     <constraint firstItem="1e3-uC-J1t" firstAttribute="leading" secondItem="VRq-Zm-nw2" secondAttribute="trailing" constant="9" id="vfP-FV-mrj"/>
                     <constraint firstItem="FOb-i6-SLf" firstAttribute="top" secondItem="REh-Co-egA" secondAttribute="bottom" constant="15" id="wE4-Im-jrX"/>
                     <constraint firstItem="e0X-yV-XWC" firstAttribute="top" secondItem="EiT-Mj-1SZ" secondAttribute="top" constant="-1" id="xBT-xn-WX9"/>

--- a/Resources/Base.lproj/Preferences.xib
+++ b/Resources/Base.lproj/Preferences.xib
@@ -13,6 +13,7 @@
                 <outlet property="categoryPopup" destination="dAB-WX-QVA" id="V2f-wZ-Eve"/>
                 <outlet property="dayOneJournalNameField" destination="Pub-fF-3Iv" id="MFh-5Y-6bZ"/>
                 <outlet property="dayOneJournalTopConstraint" destination="2Vc-JD-K7Y" id="wIG-Ca-Lbc"/>
+                <outlet property="dayOneReturnButton" destination="76n-nb-d2Y" id="vjf-PC-pTS"/>
                 <outlet property="messageField" destination="UK6-9N-kOk" id="6BJ-sH-62d"/>
                 <outlet property="messageHeader" destination="e0X-yV-XWC" id="tBC-Oe-FZ4"/>
                 <outlet property="messageTopConstraint" destination="xBT-xn-WX9" id="drj-is-oYf"/>
@@ -353,6 +354,9 @@
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
+                        <connections>
+                            <action selector="dayOneTextChanged:" target="-2" id="AVD-sZ-QBm"/>
+                        </connections>
                     </textField>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="76n-nb-d2Y" userLabel="Day One Return Button">
                         <rect key="frame" x="371" y="24" width="22" height="22"/>
@@ -364,14 +368,10 @@
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
+                        <connections>
+                            <action selector="dayOneJournalReturnClicked:" target="-2" id="PCY-Vz-c5Q"/>
+                        </connections>
                     </button>
-                    <progressIndicator wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" displayedWhenStopped="NO" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="wkZ-P7-NAg" userLabel="Day One Progress Indicator">
-                        <rect key="frame" x="374" y="27" width="16" height="16"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="16" id="BfB-1U-grd"/>
-                            <constraint firstAttribute="height" constant="16" id="uI5-QN-ohS"/>
-                        </constraints>
-                    </progressIndicator>
                 </subviews>
                 <constraints>
                     <constraint firstItem="GX3-D2-htv" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="20" id="0cP-Yy-b90"/>
@@ -390,7 +390,6 @@
                     <constraint firstItem="zil-dW-qZT" firstAttribute="top" secondItem="blp-LE-vz2" secondAttribute="bottom" id="CNW-ti-bgO"/>
                     <constraint firstItem="VRq-Zm-nw2" firstAttribute="top" secondItem="T0C-fL-nk1" secondAttribute="bottom" constant="24" id="DWl-mp-mwJ"/>
                     <constraint firstAttribute="trailing" secondItem="zil-dW-qZT" secondAttribute="trailing" constant="20" id="EaY-Ck-kva"/>
-                    <constraint firstItem="wkZ-P7-NAg" firstAttribute="centerY" secondItem="Pub-fF-3Iv" secondAttribute="centerY" id="FOl-LK-PkB"/>
                     <constraint firstAttribute="trailing" secondItem="GX3-D2-htv" secondAttribute="trailing" constant="20" id="GCf-da-Abr"/>
                     <constraint firstItem="yk6-d0-KBL" firstAttribute="leading" secondItem="1e3-uC-J1t" secondAttribute="trailing" constant="5" id="HSh-kT-1cn"/>
                     <constraint firstItem="Jez-ql-5hu" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="20" id="Hh4-2N-kdd"/>
@@ -400,7 +399,6 @@
                     <constraint firstItem="uK0-xJ-ygW" firstAttribute="top" secondItem="1e3-uC-J1t" secondAttribute="bottom" constant="49" id="Lag-vY-Nzf"/>
                     <constraint firstItem="blp-LE-vz2" firstAttribute="leading" secondItem="HEb-qM-PKK" secondAttribute="trailing" constant="8" id="MiD-b5-sLP"/>
                     <constraint firstItem="zil-dW-qZT" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="20" id="NMp-LJ-WFw"/>
-                    <constraint firstItem="GsW-0h-utd" firstAttribute="width" secondItem="wkZ-P7-NAg" secondAttribute="width" id="ON2-NW-3QM"/>
                     <constraint firstItem="iVr-XZ-NWu" firstAttribute="top" secondItem="e0X-yV-XWC" secondAttribute="bottom" constant="17" id="P9q-Qh-2kS"/>
                     <constraint firstItem="e0X-yV-XWC" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="-1" id="PnO-91-67S"/>
                     <constraint firstItem="GX3-D2-htv" firstAttribute="top" secondItem="VRq-Zm-nw2" secondAttribute="bottom" constant="22" id="Q2Z-oj-qtK"/>
@@ -434,7 +432,6 @@
                     <constraint firstItem="wxE-lU-Q6W" firstAttribute="top" secondItem="e0X-yV-XWC" secondAttribute="bottom" constant="18" id="tWe-du-IoH"/>
                     <constraint firstItem="tcY-90-dE6" firstAttribute="top" secondItem="FOb-i6-SLf" secondAttribute="bottom" constant="22" id="tjl-fl-Q18"/>
                     <constraint firstItem="Jez-ql-5hu" firstAttribute="top" secondItem="zil-dW-qZT" secondAttribute="bottom" constant="15" id="vDa-At-JUF"/>
-                    <constraint firstItem="GsW-0h-utd" firstAttribute="centerX" secondItem="wkZ-P7-NAg" secondAttribute="centerX" id="vLC-QV-2t4"/>
                     <constraint firstItem="1e3-uC-J1t" firstAttribute="leading" secondItem="VRq-Zm-nw2" secondAttribute="trailing" constant="9" id="vfP-FV-mrj"/>
                     <constraint firstItem="FOb-i6-SLf" firstAttribute="top" secondItem="REh-Co-egA" secondAttribute="bottom" constant="15" id="wE4-Im-jrX"/>
                     <constraint firstItem="e0X-yV-XWC" firstAttribute="top" secondItem="EiT-Mj-1SZ" secondAttribute="top" constant="-1" id="xBT-xn-WX9"/>

--- a/Resources/Base.lproj/Preferences.xib
+++ b/Resources/Base.lproj/Preferences.xib
@@ -21,9 +21,9 @@
                 <outlet property="progressSpinner" destination="GsW-0h-utd" id="Gty-Zd-J7e"/>
                 <outlet property="publishHostedBlog" destination="8Eh-Mk-bT3" id="msC-FJ-7pL"/>
                 <outlet property="publishWordPressBlog" destination="T0C-fL-nk1" id="uJN-8G-DXX"/>
-                <outlet property="returnButton" destination="yk6-d0-KBL" id="Z43-hF-jJz"/>
                 <outlet property="textSizePopup" destination="iVr-XZ-NWu" id="Sk4-Pd-Oiw"/>
                 <outlet property="websiteField" destination="1e3-uC-J1t" id="MVu-b2-eYH"/>
+                <outlet property="websiteReturnButton" destination="yk6-d0-KBL" id="Z43-hF-jJz"/>
                 <outlet property="window" destination="QvC-M9-y7g" id="hRW-hv-vMb"/>
                 <outlet property="wordPressSeparatorLine" destination="GX3-D2-htv" id="p1R-v1-Bdj"/>
             </connections>
@@ -165,7 +165,7 @@
                             <font key="font" metaFont="system"/>
                         </buttonCell>
                         <connections>
-                            <action selector="returnButtonPressed:" target="-2" id="SLN-fq-IXg"/>
+                            <action selector="websiteReturnButtonPressed:" target="-2" id="SLN-fq-IXg"/>
                         </connections>
                     </button>
                     <box boxType="custom" borderType="line" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="e0X-yV-XWC">

--- a/Resources/Base.lproj/Preferences.xib
+++ b/Resources/Base.lproj/Preferences.xib
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="RFPreferencesController">
             <connections>
                 <outlet property="accountsCollectionView" destination="DGw-lX-VIZ" id="BE2-da-DPs"/>
+                <outlet property="categoryField" destination="n60-Ec-rID" id="tdP-C0-zLA"/>
                 <outlet property="categoryPopup" destination="dAB-WX-QVA" id="V2f-wZ-Eve"/>
+                <outlet property="dayOneJournalNameField" destination="Pub-fF-3Iv" id="MFh-5Y-6bZ"/>
+                <outlet property="dayOneJournalTopConstraint" destination="2Vc-JD-K7Y" id="wIG-Ca-Lbc"/>
                 <outlet property="messageField" destination="UK6-9N-kOk" id="6BJ-sH-62d"/>
                 <outlet property="messageHeader" destination="e0X-yV-XWC" id="tBC-Oe-FZ4"/>
                 <outlet property="messageTopConstraint" destination="xBT-xn-WX9" id="drj-is-oYf"/>
+                <outlet property="postFormatField" destination="TEJ-Cy-YA6" id="8F0-g7-Wpe"/>
                 <outlet property="postFormatPopup" destination="uK0-xJ-ygW" id="Ygg-pX-V8O"/>
                 <outlet property="progressSpinner" destination="GsW-0h-utd" id="Gty-Zd-J7e"/>
                 <outlet property="publishHostedBlog" destination="8Eh-Mk-bT3" id="msC-FJ-7pL"/>
@@ -29,14 +33,14 @@
         <window title="Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="61" y="510" width="408" height="424"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1792" height="1095"/>
+            <rect key="contentRect" x="61" y="510" width="408" height="521"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1025"/>
             <view key="contentView" wantsLayer="YES" id="EiT-Mj-1SZ">
-                <rect key="frame" x="0.0" y="0.0" width="408" height="424"/>
+                <rect key="frame" x="0.0" y="0.0" width="408" height="521"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Jez-ql-5hu">
-                        <rect key="frame" x="18" y="243" width="353" height="17"/>
+                        <rect key="frame" x="18" y="340" width="353" height="17"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="17" id="72W-M2-mHg"/>
                         </constraints>
@@ -47,7 +51,7 @@
                         </textFieldCell>
                     </textField>
                     <button translatesAutoresizingMaskIntoConstraints="NO" id="8Eh-Mk-bT3">
-                        <rect key="frame" x="40" y="204" width="351" height="26"/>
+                        <rect key="frame" x="40" y="301" width="351" height="26"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="24" id="chk-Qv-wXe"/>
                         </constraints>
@@ -60,7 +64,7 @@
                         </connections>
                     </button>
                     <button translatesAutoresizingMaskIntoConstraints="NO" id="T0C-fL-nk1">
-                        <rect key="frame" x="40" y="174" width="351" height="26"/>
+                        <rect key="frame" x="40" y="271" width="351" height="26"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="24" id="El6-Vj-NCv"/>
                         </constraints>
@@ -73,7 +77,7 @@
                         </connections>
                     </button>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VRq-Zm-nw2">
-                        <rect key="frame" x="14" y="127" width="95" height="24"/>
+                        <rect key="frame" x="14" y="224" width="95" height="24"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="24" id="Uya-BL-vGE"/>
                             <constraint firstAttribute="width" constant="91" id="nbo-YH-K7C"/>
@@ -85,7 +89,7 @@
                         </textFieldCell>
                     </textField>
                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1e3-uC-J1t">
-                        <rect key="frame" x="116" y="131" width="250" height="22"/>
+                        <rect key="frame" x="116" y="228" width="250" height="22"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="22" id="CAH-uE-8ku"/>
                         </constraints>
@@ -99,14 +103,14 @@
                         </connections>
                     </textField>
                     <progressIndicator wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" displayedWhenStopped="NO" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="GsW-0h-utd">
-                        <rect key="frame" x="374" y="134" width="16" height="16"/>
+                        <rect key="frame" x="374" y="231" width="16" height="16"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="16" id="Fcm-Af-nHN"/>
                             <constraint firstAttribute="width" constant="16" id="eQd-YB-KqL"/>
                         </constraints>
                     </progressIndicator>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="TEJ-Cy-YA6">
-                        <rect key="frame" x="14" y="58" width="95" height="24"/>
+                        <rect key="frame" x="14" y="155" width="95" height="24"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="91" id="ibg-dE-9nA"/>
                             <constraint firstAttribute="height" constant="24" id="y8f-lp-3yk"/>
@@ -118,7 +122,7 @@
                         </textFieldCell>
                     </textField>
                     <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="uK0-xJ-ygW">
-                        <rect key="frame" x="112" y="57" width="259" height="26"/>
+                        <rect key="frame" x="112" y="154" width="259" height="26"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="21" id="Vyu-QU-bIa"/>
                         </constraints>
@@ -151,7 +155,7 @@
                         </connections>
                     </popUpButton>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yk6-d0-KBL">
-                        <rect key="frame" x="371" y="130" width="22" height="22"/>
+                        <rect key="frame" x="371" y="227" width="22" height="22"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="22" id="OZ3-Xu-gCe"/>
                             <constraint firstAttribute="height" constant="22" id="PNp-j7-APy"/>
@@ -165,7 +169,7 @@
                         </connections>
                     </button>
                     <box boxType="custom" borderType="line" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="e0X-yV-XWC">
-                        <rect key="frame" x="-1" y="381" width="410" height="44"/>
+                        <rect key="frame" x="-1" y="478" width="410" height="44"/>
                         <view key="contentView" id="VvB-5a-XVB">
                             <rect key="frame" x="1" y="1" width="408" height="42"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -188,13 +192,13 @@
                         <color key="fillColor" white="0.81999999999999995" alpha="0.5" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </box>
                     <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="GX3-D2-htv">
-                        <rect key="frame" x="20" y="102" width="368" height="5"/>
+                        <rect key="frame" x="20" y="199" width="368" height="5"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="1" id="Wya-wX-BWq"/>
                         </constraints>
                     </box>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="n60-Ec-rID">
-                        <rect key="frame" x="14" y="20" width="95" height="24"/>
+                        <rect key="frame" x="14" y="117" width="95" height="24"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="24" id="YfQ-a0-c48"/>
                             <constraint firstAttribute="width" constant="91" id="smF-A2-WiH"/>
@@ -206,7 +210,7 @@
                         </textFieldCell>
                     </textField>
                     <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dAB-WX-QVA">
-                        <rect key="frame" x="112" y="19" width="259" height="26"/>
+                        <rect key="frame" x="112" y="116" width="259" height="26"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="21" id="h1e-p3-Lte"/>
                         </constraints>
@@ -226,7 +230,7 @@
                         </connections>
                     </popUpButton>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wxE-lU-Q6W">
-                        <rect key="frame" x="20" y="346" width="89" height="17"/>
+                        <rect key="frame" x="20" y="443" width="89" height="17"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="17" id="Aa9-b6-IXn"/>
                             <constraint firstAttribute="width" constant="85" id="yqz-H4-whM"/>
@@ -238,7 +242,7 @@
                         </textFieldCell>
                     </textField>
                     <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="iVr-XZ-NWu">
-                        <rect key="frame" x="112" y="339" width="259" height="26"/>
+                        <rect key="frame" x="112" y="436" width="259" height="26"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="21" id="z3W-eI-vcY"/>
                         </constraints>
@@ -264,13 +268,13 @@
                         </connections>
                     </popUpButton>
                     <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="zil-dW-qZT">
-                        <rect key="frame" x="20" y="273" width="368" height="5"/>
+                        <rect key="frame" x="20" y="370" width="368" height="5"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="1" id="DMg-bQ-cve"/>
                         </constraints>
                     </box>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="HEb-qM-PKK">
-                        <rect key="frame" x="14" y="298" width="95" height="17"/>
+                        <rect key="frame" x="14" y="395" width="95" height="17"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="91" id="mLb-bm-gRx"/>
                             <constraint firstAttribute="height" constant="17" id="rRH-Cl-aEq"/>
@@ -282,7 +286,7 @@
                         </textFieldCell>
                     </textField>
                     <scrollView wantsLayer="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" usesPredominantAxisScrolling="NO" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="blp-LE-vz2">
-                        <rect key="frame" x="115" y="276" width="254" height="50"/>
+                        <rect key="frame" x="115" y="373" width="254" height="50"/>
                         <clipView key="contentView" id="wjv-wO-AkB">
                             <rect key="frame" x="0.0" y="0.0" width="254" height="50"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -310,11 +314,54 @@
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
                     </scrollView>
+                    <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="REh-Co-egA" userLabel="Dau One Separator">
+                        <rect key="frame" x="20" y="96" width="368" height="5"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="1" id="6aI-dM-5yJ"/>
+                        </constraints>
+                    </box>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FOb-i6-SLf" userLabel="Day On Descrription Label">
+                        <rect key="frame" x="18" y="66" width="372" height="17"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="17" id="sF1-CU-0Ia"/>
+                        </constraints>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="When exporting to Day One, import in Journal:" id="hBB-Lz-fhb">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tcY-90-dE6" userLabel="Day One Journal Label">
+                        <rect key="frame" x="14" y="20" width="95" height="24"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="91" id="4PM-QL-MHu"/>
+                            <constraint firstAttribute="height" constant="24" id="OEe-TB-F4N"/>
+                        </constraints>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" enabled="NO" sendsActionOnEndEditing="YES" alignment="right" title="Journal Name:" id="alj-HT-Zha">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Pub-fF-3Iv" userLabel="Day One Journal">
+                        <rect key="frame" x="116" y="24" width="250" height="22"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="22" id="yhB-fK-0Hb"/>
+                        </constraints>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="JbR-lR-p8a">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
                 </subviews>
                 <constraints>
                     <constraint firstItem="GX3-D2-htv" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="20" id="0cP-Yy-b90"/>
+                    <constraint firstItem="1e3-uC-J1t" firstAttribute="centerX" secondItem="Pub-fF-3Iv" secondAttribute="centerX" id="2PY-vB-PxE"/>
+                    <constraint firstItem="REh-Co-egA" firstAttribute="top" secondItem="VRq-Zm-nw2" secondAttribute="bottom" constant="125" id="2Vc-JD-K7Y"/>
                     <constraint firstItem="T0C-fL-nk1" firstAttribute="top" secondItem="8Eh-Mk-bT3" secondAttribute="bottom" constant="6" id="3da-gk-kfJ"/>
                     <constraint firstItem="8Eh-Mk-bT3" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="42" id="4CE-36-o2v"/>
+                    <constraint firstItem="FOb-i6-SLf" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="20" id="58R-Wf-R11"/>
                     <constraint firstItem="wxE-lU-Q6W" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="22" id="7OH-fG-nbE"/>
                     <constraint firstItem="n60-Ec-rID" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="16" id="7Xp-5a-h4u"/>
                     <constraint firstAttribute="trailing" secondItem="uK0-xJ-ygW" secondAttribute="trailing" constant="41" id="7yX-us-wcM"/>
@@ -329,6 +376,7 @@
                     <constraint firstItem="yk6-d0-KBL" firstAttribute="leading" secondItem="1e3-uC-J1t" secondAttribute="trailing" constant="5" id="HSh-kT-1cn"/>
                     <constraint firstItem="Jez-ql-5hu" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="20" id="Hh4-2N-kdd"/>
                     <constraint firstItem="dAB-WX-QVA" firstAttribute="leading" secondItem="n60-Ec-rID" secondAttribute="trailing" constant="8" id="KEd-IF-yKK"/>
+                    <constraint firstAttribute="trailing" secondItem="Pub-fF-3Iv" secondAttribute="trailing" constant="42" id="KZm-ar-S93"/>
                     <constraint firstItem="blp-LE-vz2" firstAttribute="top" secondItem="iVr-XZ-NWu" secondAttribute="bottom" constant="17" id="LNE-pK-FMy"/>
                     <constraint firstItem="uK0-xJ-ygW" firstAttribute="top" secondItem="1e3-uC-J1t" secondAttribute="bottom" constant="49" id="Lag-vY-Nzf"/>
                     <constraint firstItem="blp-LE-vz2" firstAttribute="leading" secondItem="HEb-qM-PKK" secondAttribute="trailing" constant="8" id="MiD-b5-sLP"/>
@@ -336,15 +384,21 @@
                     <constraint firstItem="iVr-XZ-NWu" firstAttribute="top" secondItem="e0X-yV-XWC" secondAttribute="bottom" constant="17" id="P9q-Qh-2kS"/>
                     <constraint firstItem="e0X-yV-XWC" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="-1" id="PnO-91-67S"/>
                     <constraint firstItem="GX3-D2-htv" firstAttribute="top" secondItem="VRq-Zm-nw2" secondAttribute="bottom" constant="22" id="Q2Z-oj-qtK"/>
+                    <constraint firstItem="1e3-uC-J1t" firstAttribute="width" secondItem="Pub-fF-3Iv" secondAttribute="width" id="QJ4-mz-v1h"/>
                     <constraint firstItem="GsW-0h-utd" firstAttribute="top" secondItem="T0C-fL-nk1" secondAttribute="bottom" constant="25" id="Ray-VT-9TY"/>
                     <constraint firstItem="TEJ-Cy-YA6" firstAttribute="top" secondItem="VRq-Zm-nw2" secondAttribute="bottom" constant="45" id="TPU-ao-7Na"/>
                     <constraint firstAttribute="trailing" secondItem="GsW-0h-utd" secondAttribute="trailing" constant="18" id="Tyc-XP-QvY"/>
                     <constraint firstAttribute="trailing" secondItem="8Eh-Mk-bT3" secondAttribute="trailing" constant="17" id="V8p-0o-iUT"/>
+                    <constraint firstAttribute="trailing" secondItem="REh-Co-egA" secondAttribute="trailing" constant="20" id="VPy-Sl-4NX"/>
                     <constraint firstAttribute="trailing" secondItem="iVr-XZ-NWu" secondAttribute="trailing" constant="41" id="XBw-hU-eFB"/>
                     <constraint firstItem="T0C-fL-nk1" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="42" id="XF4-cR-bFU"/>
                     <constraint firstItem="VRq-Zm-nw2" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="16" id="Y0c-bg-nra"/>
                     <constraint firstItem="dAB-WX-QVA" firstAttribute="top" secondItem="uK0-xJ-ygW" secondAttribute="bottom" constant="17" id="aHe-ru-3FA"/>
+                    <constraint firstItem="REh-Co-egA" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="20" id="aVP-lc-0eB"/>
                     <constraint firstAttribute="trailing" secondItem="Jez-ql-5hu" secondAttribute="trailing" constant="39" id="afB-9y-YML"/>
+                    <constraint firstItem="tcY-90-dE6" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="16" id="bQZ-aY-wm8"/>
+                    <constraint firstAttribute="trailing" secondItem="FOb-i6-SLf" secondAttribute="trailing" constant="20" id="cDl-HJ-age"/>
+                    <constraint firstItem="Pub-fF-3Iv" firstAttribute="leading" secondItem="tcY-90-dE6" secondAttribute="trailing" constant="9" id="cNB-4Y-zpS"/>
                     <constraint firstItem="iVr-XZ-NWu" firstAttribute="leading" secondItem="wxE-lU-Q6W" secondAttribute="trailing" constant="8" id="ctQ-ZB-NQM"/>
                     <constraint firstItem="yk6-d0-KBL" firstAttribute="top" secondItem="T0C-fL-nk1" secondAttribute="bottom" constant="23" id="eZ9-66-wrY"/>
                     <constraint firstAttribute="trailing" secondItem="dAB-WX-QVA" secondAttribute="trailing" constant="41" id="iab-wJ-4Hp"/>
@@ -353,15 +407,18 @@
                     <constraint firstItem="n60-Ec-rID" firstAttribute="top" secondItem="TEJ-Cy-YA6" secondAttribute="bottom" constant="14" id="kbl-Ri-LVu"/>
                     <constraint firstItem="TEJ-Cy-YA6" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="16" id="mzZ-RR-i7f"/>
                     <constraint firstItem="1e3-uC-J1t" firstAttribute="top" secondItem="T0C-fL-nk1" secondAttribute="bottom" constant="22" id="pdg-GY-Z4a"/>
+                    <constraint firstItem="Pub-fF-3Iv" firstAttribute="firstBaseline" secondItem="tcY-90-dE6" secondAttribute="firstBaseline" id="q06-Py-ZmY"/>
                     <constraint firstItem="wxE-lU-Q6W" firstAttribute="top" secondItem="e0X-yV-XWC" secondAttribute="bottom" constant="18" id="tWe-du-IoH"/>
+                    <constraint firstItem="tcY-90-dE6" firstAttribute="top" secondItem="FOb-i6-SLf" secondAttribute="bottom" constant="22" id="tjl-fl-Q18"/>
                     <constraint firstItem="Jez-ql-5hu" firstAttribute="top" secondItem="zil-dW-qZT" secondAttribute="bottom" constant="15" id="vDa-At-JUF"/>
                     <constraint firstItem="1e3-uC-J1t" firstAttribute="leading" secondItem="VRq-Zm-nw2" secondAttribute="trailing" constant="9" id="vfP-FV-mrj"/>
+                    <constraint firstItem="FOb-i6-SLf" firstAttribute="top" secondItem="REh-Co-egA" secondAttribute="bottom" constant="15" id="wE4-Im-jrX"/>
                     <constraint firstItem="e0X-yV-XWC" firstAttribute="top" secondItem="EiT-Mj-1SZ" secondAttribute="top" constant="-1" id="xBT-xn-WX9"/>
                     <constraint firstAttribute="trailing" secondItem="blp-LE-vz2" secondAttribute="trailing" constant="39" id="xR4-Qy-JNw"/>
                     <constraint firstAttribute="trailing" secondItem="T0C-fL-nk1" secondAttribute="trailing" constant="17" id="zCQ-mM-ySq"/>
                 </constraints>
             </view>
-            <point key="canvasLocation" x="41" y="169"/>
+            <point key="canvasLocation" x="-513" y="48"/>
         </window>
     </objects>
 </document>

--- a/Source/RFAppDelegate.m
+++ b/Source/RFAppDelegate.m
@@ -398,26 +398,36 @@
 {
 	if ([RFDayOneExportController checkForDayOne]) {
         for (RFAccount* a in [RFSettings accounts]) {
-            NSString* s = [RFSettings stringForKey:kDayOneJournalName account:a];
-            NSString* j = @"Default";
-            NSString* alertDescription = @"Micro.blog will download your posts and add them to the default journal in Day One. To test the import first, create a new Day One journal and move it to the top of your list in Day One's preferences.";
-            NSString* alertDescriptionJournal = @"Micro.blog will download your posts and add them to the specified journal in Day One. If the specified journal doesn't exist, create it first or rename the journal in Micro.blog's Preferences window.";
-
-            if (s != nil && s.length > 0) {
-                j = s;
-                alertDescription = alertDescriptionJournal;
-            }
-
-            NSString* alertTitle = [NSString stringWithFormat:@"Day One %@ Journal", j];
-
-            [NSAlert rf_showTwoButtonAlert:alertTitle message:alertDescriptionJournal okButton:@"Continue" cancelButton:@"Cancel" completionHandler:^(NSModalResponse returnCode) {
+            NSString* accountTitle = [NSString stringWithFormat:@"Export posts for the account %@?", a.username];
+            [NSAlert rf_showTwoButtonAlert:accountTitle message:@"" okButton:@"Yes" cancelButton:@"No" completionHandler:^(NSModalResponse returnCode) {
                 if (returnCode == 1000) {
-                    self.exportController = [[RFDayOneExportController alloc] init];
-                    [self.exportController showWindow:nil];
+                    [self exportDayOneForAccount:a];
                 }
             }];
         }
 	}
+}
+
+- (void)exportDayOneForAccount:(RFAccount* )a
+{
+    NSString* s = [RFSettings stringForKey:kDayOneJournalName account:a];
+    NSString* j = @"Default";
+    NSString* alertDescription = @"Micro.blog will download your posts and add them to the default journal in Day One. To test the import first, create a new Day One journal and move it to the top of your list in Day One's preferences.";
+    NSString* alertDescriptionJournal = @"Micro.blog will download your posts and add them to the specified journal in Day One. If the specified journal doesn't exist, create it first or rename the journal in Micro.blog's Preferences window.";
+
+    if (s != nil && s.length > 0) {
+        j = s;
+        alertDescription = alertDescriptionJournal;
+    }
+
+    NSString* alertTitle = [NSString stringWithFormat:@"Day One %@ Journal", j];
+
+    [NSAlert rf_showTwoButtonAlert:alertTitle message:alertDescriptionJournal okButton:@"Continue" cancelButton:@"Cancel" completionHandler:^(NSModalResponse returnCode) {
+        if (returnCode == 1000) {
+            self.exportController = [[RFDayOneExportController alloc] initWithAccount:a];
+            [self.exportController showWindow:nil];
+        }
+    }];
 }
 
 - (IBAction) signOut:(id)sender

--- a/Source/RFAppDelegate.m
+++ b/Source/RFAppDelegate.m
@@ -397,12 +397,26 @@
 - (IBAction) exportDayOne:(id)sender
 {
 	if ([RFDayOneExportController checkForDayOne]) {
-		[NSAlert rf_showTwoButtonAlert:@"Day One Default Journal" message:@"Micro.blog will download your posts and add them to the default journal in Day One. To test the import first, create a new Day One journal and move it to the top of your list in Day One's preferences." okButton:@"Continue" cancelButton:@"Cancel" completionHandler:^(NSModalResponse returnCode) {
-			if (returnCode == 1000) {
-				self.exportController = [[RFDayOneExportController alloc] init];
-				[self.exportController showWindow:nil];
-			}
-		}];
+        for (RFAccount* a in [RFSettings accounts]) {
+            NSString* s = [RFSettings stringForKey:kDayOneJournalName account:a];
+            NSString* j = @"Default";
+            NSString* alertDescription = @"Micro.blog will download your posts and add them to the default journal in Day One. To test the import first, create a new Day One journal and move it to the top of your list in Day One's preferences.";
+            NSString* alertDescriptionJournal = @"Micro.blog will download your posts and add them to the specified journal in Day One. If the specified journal doesn't exist, create it first or rename the journal in Micro.blog's Preferences window.";
+
+            if (s != nil && s.length > 0) {
+                j = s;
+                alertDescription = alertDescriptionJournal;
+            }
+
+            NSString* alertTitle = [NSString stringWithFormat:@"Day One %@ Journal", j];
+
+            [NSAlert rf_showTwoButtonAlert:alertTitle message:alertDescriptionJournal okButton:@"Continue" cancelButton:@"Cancel" completionHandler:^(NSModalResponse returnCode) {
+                if (returnCode == 1000) {
+                    self.exportController = [[RFDayOneExportController alloc] init];
+                    [self.exportController showWindow:nil];
+                }
+            }];
+        }
 	}
 }
 

--- a/Source/RFDayOneExportController.h
+++ b/Source/RFDayOneExportController.h
@@ -8,10 +8,15 @@
 
 #import "RFExportController.h"
 
+@class RFAccount;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface RFDayOneExportController : RFExportController
 
+@property (strong, nonatomic, readonly) RFAccount* account;
+
+- (instancetype) initWithAccount:(RFAccount *)account;
 + (BOOL) checkForDayOne;
 
 @end

--- a/Source/RFDayOneExportController.m
+++ b/Source/RFDayOneExportController.m
@@ -9,6 +9,7 @@
 #import "RFDayOneExportController.h"
 
 #import "RFPost.h"
+#import "RFSettings.h"
 #import "NSAlert+Extras.h"
 #import "HTMLParser.h"
 
@@ -122,7 +123,11 @@ static NSString* const kDayOneHelpPageURL = @"https://help.dayoneapp.com/en/arti
 	NSFileHandle* f = [NSFileHandle fileHandleForReadingAtPath:path];
 	NSString* d = [post.postedAt description];
 
-	[args addObjectsFromArray:@[ @"-d", d, @"--", @"new"]];
+    if (self.journalName) {
+        [args addObjectsFromArray:@[@"-j", self.journalName]];
+    }
+
+	[args addObjectsFromArray:@[@"-d", d, @"--", @"new"]];
 	
 	NSTask* t = [[NSTask alloc] init];
 	t.launchPath = kDayOneCommandLinePath;
@@ -131,6 +136,17 @@ static NSString* const kDayOneHelpPageURL = @"https://help.dayoneapp.com/en/arti
 	
 	[t launch];
 	[t waitUntilExit];
+}
+
+- (NSString *) journalName
+{
+    NSString *s = [RFSettings stringForKey:kDayOneJournalName];
+
+    if (s != nil && s.length > 0) {
+        return s;
+    } else {
+        return nil;
+    }
 }
 
 - (NSString *) writePost:(RFPost *)post

--- a/Source/RFDayOneExportController.m
+++ b/Source/RFDayOneExportController.m
@@ -16,7 +16,24 @@
 static NSString* const kDayOneCommandLinePath = @"/usr/local/bin/dayone2";
 static NSString* const kDayOneHelpPageURL = @"https://help.dayoneapp.com/en/articles/435871-command-line-interface-cli";
 
+@interface RFDayOneExportController ()
+
+@property (readwrite) RFAccount* account;
+
+@end
+
 @implementation RFDayOneExportController
+
+- (instancetype) initWithAccount:(RFAccount *)account
+{
+    self = [super init];
+
+    if (self) {
+        self.account = account;
+    }
+
+    return self;
+}
 
 - (void) windowDidLoad
 {
@@ -140,7 +157,7 @@ static NSString* const kDayOneHelpPageURL = @"https://help.dayoneapp.com/en/arti
 
 - (NSString *) journalName
 {
-    NSString *s = [RFSettings stringForKey:kDayOneJournalName];
+    NSString *s = [RFSettings stringForKey:kDayOneJournalName account:self.account];
 
     if (s != nil && s.length > 0) {
         return s;

--- a/Source/RFInstagramController.m
+++ b/Source/RFInstagramController.m
@@ -46,7 +46,7 @@ static NSString* const kPhotoCellIdentifier = @"PhotoCell";
 
 	[self setupHostname];
 	[self setupSummary];
-	[self setupColletionView];
+	[self setupCollectionView];
 }
 
 - (void) setupPhotos
@@ -113,7 +113,7 @@ static NSString* const kPhotoCellIdentifier = @"PhotoCell";
 	}
 }
 
-- (void) setupColletionView
+- (void) setupCollectionView
 {
 	self.collectionView.delegate = self;
 	self.collectionView.dataSource = self;

--- a/Source/RFPostController.m
+++ b/Source/RFPostController.m
@@ -128,7 +128,7 @@ static CGFloat const kTextViewTitleShownTop = 54;
 
 	[self setupTitle];
 	[self setupText];
-	[self setupColletionView];
+	[self setupCollectionView];
 	[self setupBlogName];
 	[self setupButtons];
 	[self setupNotifications];
@@ -225,7 +225,7 @@ static CGFloat const kTextViewTitleShownTop = 54;
 	}
 }
 
-- (void) setupColletionView
+- (void) setupCollectionView
 {
 	self.photosCollectionView.delegate = self;
 	self.photosCollectionView.dataSource = self;

--- a/Source/RFPreferencesController.h
+++ b/Source/RFPreferencesController.h
@@ -30,6 +30,7 @@
 @property (strong, nonatomic) IBOutlet NSBox* wordPressSeparatorLine;
 @property (strong, nonatomic) IBOutlet NSTextField* dayOneJournalNameField;
 @property (strong, nonatomic) IBOutlet NSLayoutConstraint* dayOneJournalTopConstraint;
+@property (strong, nonatomic) IBOutlet NSButton* dayOneReturnButton;
 
 @property (strong, nonatomic) RFWordpressController* wordpressController;
 @property (assign, nonatomic) BOOL hasShownWindow;

--- a/Source/RFPreferencesController.h
+++ b/Source/RFPreferencesController.h
@@ -21,11 +21,15 @@
 @property (strong, nonatomic) IBOutlet NSButton* returnButton;
 @property (strong, nonatomic) IBOutlet NSTextField* websiteField;
 @property (strong, nonatomic) IBOutlet NSProgressIndicator* progressSpinner;
+@property (strong, nonatomic) IBOutlet NSTextField *postFormatField;
 @property (strong, nonatomic) IBOutlet NSPopUpButton* postFormatPopup;
+@property (strong, nonatomic) IBOutlet NSTextField *categoryField;
 @property (strong, nonatomic) IBOutlet NSPopUpButton* categoryPopup;
 @property (strong, nonatomic) IBOutlet NSPopUpButton* textSizePopup;
 @property (strong, nonatomic) IBOutlet NSCollectionView* accountsCollectionView;
 @property (strong, nonatomic) IBOutlet NSBox* wordPressSeparatorLine;
+@property (strong, nonatomic) IBOutlet NSTextField* dayOneJournalNameField;
+@property (strong, nonatomic) IBOutlet NSLayoutConstraint* dayOneJournalTopConstraint;
 
 @property (strong, nonatomic) RFWordpressController* wordpressController;
 @property (assign, nonatomic) BOOL hasShownWindow;

--- a/Source/RFPreferencesController.h
+++ b/Source/RFPreferencesController.h
@@ -20,7 +20,7 @@
 @property (strong, nonatomic) IBOutlet NSButton* publishWordPressBlog;
 @property (strong, nonatomic) IBOutlet NSButton* websiteReturnButton;
 @property (strong, nonatomic) IBOutlet NSTextField* websiteField;
-@property (strong, nonatomic) IBOutlet NSProgressIndicator* progressSpinner;
+@property (strong, nonatomic) IBOutlet NSProgressIndicator* websiteProgressSpinner;
 @property (strong, nonatomic) IBOutlet NSTextField *postFormatField;
 @property (strong, nonatomic) IBOutlet NSPopUpButton* postFormatPopup;
 @property (strong, nonatomic) IBOutlet NSTextField *categoryField;

--- a/Source/RFPreferencesController.h
+++ b/Source/RFPreferencesController.h
@@ -18,7 +18,7 @@
 @property (strong, nonatomic) IBOutlet NSLayoutConstraint* messageTopConstraint;
 @property (strong, nonatomic) IBOutlet NSButton* publishHostedBlog;
 @property (strong, nonatomic) IBOutlet NSButton* publishWordPressBlog;
-@property (strong, nonatomic) IBOutlet NSButton* returnButton;
+@property (strong, nonatomic) IBOutlet NSButton* websiteReturnButton;
 @property (strong, nonatomic) IBOutlet NSTextField* websiteField;
 @property (strong, nonatomic) IBOutlet NSProgressIndicator* progressSpinner;
 @property (strong, nonatomic) IBOutlet NSTextField *postFormatField;

--- a/Source/RFPreferencesController.m
+++ b/Source/RFPreferencesController.m
@@ -154,7 +154,7 @@ static NSString* const kAccountCellIdentifier = @"AccountCell";
 {
 	NSString* xmlrpc_endpoint = [RFSettings stringForKey:kExternalBlogEndpoint account:self.selectedAccount];
 	if (xmlrpc_endpoint) {
-		[self.progressSpinner startAnimation:nil];
+		[self.websiteProgressSpinner startAnimation:nil];
 
 		NSString* blog_s = [RFSettings stringForKey:kExternalBlogID account:self.selectedAccount];
 		NSString* username = [RFSettings stringForKey:kExternalBlogUsername account:self.selectedAccount];
@@ -193,7 +193,7 @@ static NSString* const kAccountCellIdentifier = @"AccountCell";
 				
 				self.hasLoadedCategories = YES;
 				[self updateMenus];
-				[self.progressSpinner stopAnimation:nil];
+				[self.websiteProgressSpinner stopAnimation:nil];
 			});
 		}];
 	}
@@ -430,7 +430,7 @@ static NSString* const kAccountCellIdentifier = @"AccountCell";
 
 - (void) checkWebsite
 {
-	[self.progressSpinner startAnimation:nil];
+	[self.websiteProgressSpinner startAnimation:nil];
 
 	NSString* full_url = [self normalizeURL:self.websiteField.stringValue];
 	[RFSettings setString:full_url forKey:kExternalBlogURL account:self.selectedAccount];
@@ -441,7 +441,7 @@ static NSString* const kAccountCellIdentifier = @"AccountCell";
 		if ([rsd_parser.foundURLs count] > 0) {
 			NSString* rsd_url = [rsd_parser.foundURLs firstObject];
             RFDispatchMainAsync (^{
-				[self.progressSpinner stopAnimation:nil];
+				[self.websiteProgressSpinner stopAnimation:nil];
 
                 self.wordpressController = [[RFWordpressController alloc] initWithWebsite:full_url rsdURL:rsd_url];
 				[self.window beginSheet:self.wordpressController.window completionHandler:^(NSModalResponse returnCode) {
@@ -479,14 +479,14 @@ static NSString* const kAccountCellIdentifier = @"AccountCell";
 					[RFSettings setString:micropub_endpoint forKey:kExternalMicropubPostingEndpoint account:self.selectedAccount];
 
 					RFDispatchMainAsync (^{
-						[self.progressSpinner stopAnimation:nil];
+						[self.websiteProgressSpinner stopAnimation:nil];
 						[[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:auth_with_params]];
 					});
 				}
 			}
 			else {
 				RFDispatchMainAsync (^{
-					[self.progressSpinner stopAnimation:nil];
+					[self.websiteProgressSpinner stopAnimation:nil];
 					[NSAlert rf_showOneButtonAlert:@"Error Discovering Settings" message:@"Could not find the XML-RPC endpoint or Micropub API for your weblog." button:@"OK" completionHandler:NULL];
 				});
 			}

--- a/Source/RFPreferencesController.m
+++ b/Source/RFPreferencesController.m
@@ -99,7 +99,7 @@ static NSString* const kAccountCellIdentifier = @"AccountCell";
 
 - (void) setupFields
 {
-	self.returnButton.alphaValue = 0.0;
+	self.websiteReturnButton.alphaValue = 0.0;
 	self.websiteField.delegate = self;
 	
 	NSString* s = [RFSettings stringForKey:kExternalBlogURL account:self.selectedAccount];
@@ -255,9 +255,9 @@ static NSString* const kAccountCellIdentifier = @"AccountCell";
 	[self showMenusIfWordPress];
 }
 
-- (IBAction) returnButtonPressed:(id)sender
+- (IBAction) websiteReturnButtonPressed:(id)sender
 {
-	[self hideReturnButton];
+	[self hideWebsiteReturnButton];
 	[self checkWebsite];
 }
 
@@ -278,16 +278,16 @@ static NSString* const kAccountCellIdentifier = @"AccountCell";
 {
 	NSString* s = self.websiteField.stringValue;
 	if (s.length > 0) {
-		[self showReturnButton];
+		[self showWebsiteReturnButton];
 	}
 	else {
-		[self hideReturnButton];
+		[self hideWebsiteReturnButton];
 	}
 }
 
 - (IBAction) websiteTextChanged:(NSTextField *)sender
 {
-	[self hideReturnButton];
+	[self hideWebsiteReturnButton];
 	if (sender.stringValue.length > 0) {
 		[self checkWebsite];
 	}
@@ -418,14 +418,14 @@ static NSString* const kAccountCellIdentifier = @"AccountCell";
 	}
 }
 
-- (void) showReturnButton
+- (void) showWebsiteReturnButton
 {
-	self.returnButton.animator.alphaValue = 1.0;
+	self.websiteReturnButton.animator.alphaValue = 1.0;
 }
 
-- (void) hideReturnButton
+- (void) hideWebsiteReturnButton
 {
-	self.returnButton.animator.alphaValue = 0.0;
+	self.websiteReturnButton.animator.alphaValue = 0.0;
 }
 
 - (void) checkWebsite

--- a/Source/RFPreferencesController.m
+++ b/Source/RFPreferencesController.m
@@ -44,7 +44,7 @@ static NSString* const kAccountCellIdentifier = @"AccountCell";
 	[self setupAccounts];
 	[self setupTextPopup];
 	[self setupNotifications];
-	[self setupColletionView];
+	[self setupCollectionView];
 	[self selectFirstAccount];
 	
 	[self setupFields];
@@ -142,7 +142,7 @@ static NSString* const kAccountCellIdentifier = @"AccountCell";
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(refreshAccountsNotification:) name:kRefreshAccountsNotification object:nil];
 }
 
-- (void) setupColletionView
+- (void) setupCollectionView
 {
 	self.accountsCollectionView.delegate = self;
 	self.accountsCollectionView.dataSource = self;

--- a/Source/RFPreferencesController.m
+++ b/Source/RFPreferencesController.m
@@ -47,7 +47,8 @@ static NSString* const kAccountCellIdentifier = @"AccountCell";
 	[self setupCollectionView];
 	[self selectFirstAccount];
 	
-	[self setupFields];
+	[self setupWebsiteField];
+    [self setupDayOneField];
 	[self updateRadioButtons];
 	[self updateMenus];
 	
@@ -97,7 +98,7 @@ static NSString* const kAccountCellIdentifier = @"AccountCell";
 	self.accounts = [self.accounts arrayByAddingObject:blank_a];
 }
 
-- (void) setupFields
+- (void) setupWebsiteField
 {
 	self.websiteReturnButton.alphaValue = 0.0;
 	self.websiteField.delegate = self;
@@ -223,7 +224,8 @@ static NSString* const kAccountCellIdentifier = @"AccountCell";
 {
 	self.selectedAccount = account;
 	
-	[self setupFields];
+	[self setupWebsiteField];
+    [self setupDayOneField];
 	[self updateRadioButtons];
 	[self updateMenus];
 
@@ -276,13 +278,18 @@ static NSString* const kAccountCellIdentifier = @"AccountCell";
 
 - (void) controlTextDidChange:(NSNotification *)notification
 {
-	NSString* s = self.websiteField.stringValue;
-	if (s.length > 0) {
-		[self showWebsiteReturnButton];
-	}
-	else {
-		[self hideWebsiteReturnButton];
-	}
+    if ([notification.object isEqual:self.websiteField]) {
+        NSString* s = self.websiteField.stringValue;
+        if (s.length > 0) {
+            [self showWebsiteReturnButton];
+        }
+        else {
+            [self hideWebsiteReturnButton];
+        }
+    }
+    else if ([notification.object isEqual:self.dayOneJournalNameField]) {
+        [self dayOneTextDidChange];
+    }
 }
 
 - (IBAction) websiteTextChanged:(NSTextField *)sender
@@ -403,6 +410,7 @@ static NSString* const kAccountCellIdentifier = @"AccountCell";
 {
 	NSString* selected_format = [RFSettings stringForKey:kExternalBlogFormat account:self.selectedAccount];
 	NSString* selected_category = [RFSettings stringForKey:kExternalBlogCategory account:self.selectedAccount];
+    NSString* selected_dayOneJournal = [RFSettings stringForKey:kDayOneJournalName account:self.selectedAccount];
 
 	if (self.hasLoadedCategories) {
 		self.postFormatPopup.enabled = YES;
@@ -416,6 +424,10 @@ static NSString* const kAccountCellIdentifier = @"AccountCell";
 	if (selected_category) {
 		[self.categoryPopup selectItemWithTag:selected_category.integerValue];
 	}
+
+    if (selected_dayOneJournal) {
+        [self.dayOneJournalNameField setStringValue:selected_dayOneJournal];
+    }
 }
 
 - (void) showWebsiteReturnButton
@@ -539,6 +551,61 @@ static NSString* const kAccountCellIdentifier = @"AccountCell";
 		RFAccount* a = [self.accounts objectAtIndex:index_path.item];
 		[self showSettingsForAccount:a];
 	}
+}
+
+#pragma mark -
+
+- (void) setupDayOneField
+{
+    self.dayOneReturnButton.hidden = YES;
+    self.dayOneJournalNameField.delegate = self;
+
+    NSString* s = [RFSettings stringForKey:kDayOneJournalName account:self.selectedAccount];
+
+    if (s) {
+        self.dayOneJournalNameField.stringValue = s;
+    }
+    else {
+        self.dayOneJournalNameField.stringValue = @"";
+    }
+}
+
+- (void) dayOneTextDidChange
+{
+    NSString* s = self.dayOneJournalNameField.stringValue;
+
+    if (s.length > 0) {
+        [self showDayOneReturnButton];
+    }
+    else {
+        [self hideDayOneReturnButton];
+    }
+}
+
+- (IBAction) dayOneTextChanged:(NSTextField *)sender
+{
+    [self saveDayOneJournal];
+}
+
+- (IBAction) dayOneJournalReturnClicked:(NSButton *)sender
+{
+    [self saveDayOneJournal];
+}
+
+- (void) showDayOneReturnButton
+{
+    self.dayOneReturnButton.hidden = NO;
+}
+
+- (void) hideDayOneReturnButton
+{
+    self.dayOneReturnButton.hidden = YES;
+}
+
+- (void) saveDayOneJournal
+{
+    [self.dayOneReturnButton setHidden:YES];
+    [RFSettings setString:self.dayOneJournalNameField.stringValue forKey:kDayOneJournalName account:self.selectedAccount];
 }
 
 @end

--- a/Source/RFPreferencesController.m
+++ b/Source/RFPreferencesController.m
@@ -52,7 +52,7 @@ static NSString* const kAccountCellIdentifier = @"AccountCell";
 	[self updateMenus];
 	
 	[self hideMessage];
-	[self hideWordPressMenus];
+    [self hideWordPressMenus];
 }
 
 - (void) windowDidBecomeKeyNotification:(NSNotification *)notification
@@ -348,8 +348,9 @@ static NSString* const kAccountCellIdentifier = @"AccountCell";
 			win_r.size.height += kWordPressMenusHeight;
 			win_r.origin.y -= kWordPressMenusHeight;
 			[self.window.animator setFrame:win_r display:YES];
-			self.wordPressSeparatorLine.hidden = NO;
-			self.isShowingWordPressMenus = YES;
+            [self setWordpressMenuVisibility: NO];
+            self.dayOneJournalTopConstraint.constant += kWordPressMenusHeight;
+            self.isShowingWordPressMenus = YES;
 		}
 	}
 	else {
@@ -357,20 +358,31 @@ static NSString* const kAccountCellIdentifier = @"AccountCell";
 			win_r.size.height -= kWordPressMenusHeight;
 			win_r.origin.y += kWordPressMenusHeight;
 			[self.window.animator setFrame:win_r display:YES];
-			self.wordPressSeparatorLine.hidden = YES;
-			self.isShowingWordPressMenus = NO;
+            [self setWordpressMenuVisibility: YES];
+            self.dayOneJournalTopConstraint.constant -= kWordPressMenusHeight;
+            self.isShowingWordPressMenus = NO;
 		}
 	}
 }
 
+- (void) setWordpressMenuVisibility:(BOOL)isHidden
+{
+    self.wordPressSeparatorLine.hidden = isHidden;
+    self.postFormatField.hidden = isHidden;
+    self.postFormatPopup.hidden = isHidden;
+    self.categoryField.hidden = isHidden;
+    self.categoryPopup.hidden = isHidden;
+}
+
 - (void) hideWordPressMenus
 {
-	NSRect win_r = self.window.frame;
-	win_r.size.height -= kWordPressMenusHeight;
-	win_r.origin.y += kWordPressMenusHeight;
-	[self.window setFrame:win_r display:YES];
-	self.wordPressSeparatorLine.hidden = YES;
-	self.isShowingWordPressMenus = NO;
+    NSRect win_r = self.window.frame;
+    win_r.size.height -= kWordPressMenusHeight;
+    win_r.origin.y += kWordPressMenusHeight;
+    [self.window setFrame:win_r display:YES];
+    [self setWordpressMenuVisibility: YES];
+    self.dayOneJournalTopConstraint.constant -= kWordPressMenusHeight;
+    self.isShowingWordPressMenus = NO;
 }
 
 - (void) updateRadioButtons

--- a/Source/RFPreferencesController.m
+++ b/Source/RFPreferencesController.m
@@ -606,6 +606,10 @@ static NSString* const kAccountCellIdentifier = @"AccountCell";
 {
     [self.dayOneReturnButton setHidden:YES];
     [RFSettings setString:self.dayOneJournalNameField.stringValue forKey:kDayOneJournalName account:self.selectedAccount];
+
+    RFDispatchMainAsync (^{
+        [NSAlert rf_showOneButtonAlert:@"Day One Journal" message:@"Make sure a Day One journal matching the informed name exists before exporting your posts." button:@"OK" completionHandler:NULL];
+    });
 }
 
 @end

--- a/Source/RFSettings.h
+++ b/Source/RFSettings.h
@@ -35,6 +35,7 @@ static NSString* const kCurrentDestinationUID = @"CurrentDestinationUID";
 static NSString* const kCurrentDestinationName = @"CurrentDestinationName";
 static NSString* const kExternalBlogFormat = @"ExternalBlogFormat";
 static NSString* const kExternalBlogCategory = @"ExternalBlogCategory";
+static NSString* const kDayOneJournalName = @"DayOneJournalName";
 
 @interface RFSettings : NSObject
 

--- a/Source/RFSettings.m
+++ b/Source/RFSettings.m
@@ -91,7 +91,7 @@
 {
 	NSString* username = [[NSUserDefaults standardUserDefaults] objectForKey:kAccountUsername];
 	if (username.length > 0) {
-		NSArray* keys = @[ kExternalBlogIsPreferred, kAccountUsername, kAccountFullName, kAccountDefaultSite, kAccountEmail, kAccountGravatarURL, kHasSnippetsBlog, kIsFullAccess, kExternalMicropubState, kExternalMicropubTokenEndpoint, kExternalMicropubMe, kExternalBlogUsername, kExternalBlogEndpoint, kExternalBlogID, kExternalBlogApp, kExternalBlogURL, kExternalMicropubPostingEndpoint, kExternalMicropubMediaEndpoint, kCurrentDestinationUID, kCurrentDestinationName, kExternalBlogFormat, kExternalBlogCategory ];
+		NSArray* keys = @[ kExternalBlogIsPreferred, kAccountUsername, kAccountFullName, kAccountDefaultSite, kAccountEmail, kAccountGravatarURL, kHasSnippetsBlog, kIsFullAccess, kExternalMicropubState, kExternalMicropubTokenEndpoint, kExternalMicropubMe, kExternalBlogUsername, kExternalBlogEndpoint, kExternalBlogID, kExternalBlogApp, kExternalBlogURL, kExternalMicropubPostingEndpoint, kExternalMicropubMediaEndpoint, kCurrentDestinationUID, kCurrentDestinationName, kExternalBlogFormat, kExternalBlogCategory, kDayOneJournalName ];
 		for (NSString* old_k in keys) {
 			NSString* new_k = [NSString stringWithFormat:@"%@_%@", username, old_k];
 			id val = [[NSUserDefaults standardUserDefaults] objectForKey:old_k];


### PR DESCRIPTION
## Description

This Pull Request adds a new option in Preferences, which allows users to specify the Day One journal they want to use to import their posts.

The Journal Information is store per account. When exporting to Day One, the user can import for all accounts or skip the account they don't want to import.

I tried to follow the coding style used in the project, but if I missed something, please let me know in the comments so that I  can update the Pull Request.

Fell free to update the strings; I've just added them as placeholders since I don't know the mood/language you want to use to communicate with users.

Additionally, I don't have multiple accounts to try, so please would test it for me? I really appreciate it.

## Screenshots

### Preferences Window

<img width="734" alt="1" src="https://user-images.githubusercontent.com/139272/172030900-7b954acb-6ab8-4388-ac51-92c560169091.png">

<img width="734" alt="2" src="https://user-images.githubusercontent.com/139272/172030908-7a758542-0f2d-4c31-bc28-a621e9c3bda6.png">

###  Exporting

<img width="734" alt="3" src="https://user-images.githubusercontent.com/139272/172030831-51fcfbeb-a70d-4077-9d4a-2d367f93c4be.png">

<img width="734" alt="4" src="https://user-images.githubusercontent.com/139272/172030834-c8744643-9074-42c8-9147-00bb1d797f79.png">

