### PR TITLE
Instagram Alternative Import

### DIFF
--- a/Source/RFInstagramController.m
+++ b/Source/RFInstagramController.m
@@ -99,10 +99,10 @@ static NSString* const kPhotoCellIdentifier = @"PhotoCell";
 	NSInteger num_selected = [self.collectionView selectionIndexPaths].count;
 	
 	if (self.photos.count == 1) {
-		self.summaryField.stringValue = [NSString stringWithFormat:@"1 photo (%lu selected)", (unsigned long)num_selected];
+		self.summaryField.stringValue = [NSString stringWithFormat:@"1 post (%lu selected)", (unsigned long)num_selected];
 	}
 	else {
-		self.summaryField.stringValue = [NSString stringWithFormat:@"%lu photos (%lu selected)", (unsigned long)self.photos.count, (unsigned long)num_selected];
+		self.summaryField.stringValue = [NSString stringWithFormat:@"%lu posts (%lu selected)", (unsigned long)self.photos.count, (unsigned long)num_selected];
 	}
 	
 	if ((num_selected > 0) && [self hasAnyBlog]) {
@@ -173,8 +173,14 @@ static NSString* const kPhotoCellIdentifier = @"PhotoCell";
 - (void) importPhoto:(NSDictionary *)info
 {
 	NSArray* media = [info objectForKey:@"media"];
-	for (NSDictionary* photo in media) {
-		NSString* caption = [photo objectForKey:@"title"];
+    NSDictionary* photo = [media firstObject];
+    NSString* caption;
+    if(media.count == 1){
+        caption = [photo objectForKey:@"title"];
+    }else{
+        caption = [info objectForKey:@"title"];
+    }
+		
 		NSString* relative_path = [photo objectForKey:@"uri"];
 		NSNumber* taken_at = [photo objectForKey:@"creation_timestamp"];
 
@@ -241,7 +247,6 @@ static NSString* const kPhotoCellIdentifier = @"PhotoCell";
 		else {
 			[self importNextPhoto];
 		}
-	}
 }
 
 - (void) importNextPhoto

--- a/Source/RFInstagramController.m
+++ b/Source/RFInstagramController.m
@@ -407,7 +407,8 @@ static NSString* const kPhotoCellIdentifier = @"PhotoCell";
 			@"content": text,
 			@"photo": photo.publishedURL,
 			@"published": [date uuRfc3339StringForUTCTimeZone],
-			@"mp-destination": destination_uid
+			@"mp-destination": destination_uid,
+            @"category": [NSArray arrayWithObjects: @"Instagram",nil]
 		};
 
 		[client postWithParams:args completion:^(UUHttpResponse* response) {
@@ -430,7 +431,8 @@ static NSString* const kPhotoCellIdentifier = @"PhotoCell";
 			@"name": @"",
 			@"content": text,
 			@"photo": photo.publishedURL,
-			@"published": [date uuRfc3339StringForUTCTimeZone]
+			@"published": [date uuRfc3339StringForUTCTimeZone],
+            @"category": [NSArray arrayWithObjects: @"Instagram",nil]
 		};
 		
 		[client postWithParams:args completion:^(UUHttpResponse* response) {


### PR DESCRIPTION
### Background

While helping my wife import her Instagram into micro.blog she ran into an unexpected behavior with the Instagram import feature.  Most of her posts include several pictures and in the import dialog only the first image from each post is shown, so when she selected a few "pictures", clicked imported and ended up with over a dozen new blog posts she was surprised.  I dug into the code and saw the import loops through all the media in each post and creates a separate blog post for each photo. I'm sure a majority of folks post only a single photo and this works great, and for those other folks the good news is all their photos are imported.

### Changes

I made some very minor changes to the Instagram import so it will now just take the first photo from each Instagram post and create a new blog post in micro.blog with just that one image.  

Next I made it so if the Instagram post had multiple photos then it will use the caption from the post rather than the photo, because in a multi-photo post there is a special caption in the parent object and the child photos are empty.  

Finally, I updated the label for selected item count to say "post" instead of "photo" to better convey what is being imported.

### Most Importantly

I don't expect these changes to actually be merged into the product since this new process does have some trade offs for those users that want to import ALL of their photos.  I just figured this was the best way to communicate it back to you.  I think it is so cool to be able to view the source code, understand the inner workings and then make this type of tweak (even if I'm not a native macOS developer).  Thanks!  Also if this just creates extra noise in your process please let me know and feel free to delete this PR.

<img width="483" alt="selected-label" src="https://user-images.githubusercontent.com/1424878/212784701-9a9fedb8-87da-4ac3-b6b3-67e490ffedc4.png">
!
